### PR TITLE
🩹 Fix broken links

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -491,8 +491,8 @@ baz = [42]; // 에러: 상수 변수는 값이 할당될 수 없습니다.
 ```
 
 [타입 체크와 캐스트](#타입-테스트-연산자) (`is` 그리고 `as`),
-[컬렉션 `if`](#컬렉션-연산자),
-그리고 [전개 연산자](#전개-연산자) (`...` 그리고 `...?`)를
+[컬렉션 `if`](#collection-operators),
+그리고 [전개 연산자](#spread-operator) (`...` 그리고 `...?`)를
 사용하는 상수 정의가 가능합니다:
 
 <?code-excerpt "misc/lib/language_tour/variables.dart (const-dart-25)"?>
@@ -1009,8 +1009,8 @@ final constantSet = const {
 Set은 list 처럼 전개 연산자 (`...` 그리고 `...?`)와
 컬렉션 `if` and `for`을 지원합니다.
 더 많은 정보를 원한다면,
-[list 전개 연산자](#전개-연산자) 그리고
-[list 컬렉션 연산자](#컬렉션-연산자)를 참고하세요.
+[list 전개 연산자](#spread-operator) 그리고
+[list 컬렉션 연산자](#collection-operators)를 참고하세요.
 
 Set에 대한 더 많은 정보를 원한다면,
 [제네릭](#제네릭) 과


### PR DESCRIPTION
일부 링크가 존재하지 않는 헤더를 참조하여 정상적으로 동작하지 않는 문제를 수정하였습니다.

해당 링크 모두 markdown 의 헤더 대신 `a` 태그의 `id` 파라미터로 구분되어 있었기 때문에 해당 값으로 대체하였습니다. 🙂

https://github.com/Coaspe/dart-ko.dev/blob/aacc4cc2c03599fab1be5490b0a037a8e5722a47/src/_guides/language/language-tour.md?plain=1#L875

https://github.com/Coaspe/dart-ko.dev/blob/aacc4cc2c03599fab1be5490b0a037a8e5722a47/src/_guides/language/language-tour.md?plain=1#L903